### PR TITLE
Fix small typos on future work slide

### DIFF
--- a/ciml.tex
+++ b/ciml.tex
@@ -587,8 +587,8 @@
       \item{Human curated dataset for supervised training}
       \item{Making our life easier}
       \item{Integrate with real life CI system}
-      \item{Expore job portability}
-      \item{Tune opitization for quick convergence}
+      \item{Explore job portability}
+      \item{Tune optimization for quick convergence}
   \end{itemize}
 \end{frame}
 


### PR DESCRIPTION
This commit just fixes some typos on the last slide.